### PR TITLE
Fixes broken composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	},
 	"autoload": {
 		"psr-0": {
-			"Jamm\\Memory": "lib/Jamm/Memory"
+			"Jamm\\Memory": "Jamm/Memory/lib"
 		}
 	},
 	"type": "library",


### PR DESCRIPTION
Composer's autoloader points to the wrong directory for autoloading with the current config.

``` php
<?php

// autoload_namespaces.php @generated by Composer

$vendorDir = dirname(dirname(__FILE__));
$baseDir = dirname($vendorDir);

return array(
    'Jamm\\Memory' => array($vendorDir . '/jamm/memory/lib/Jamm/Memory'), 
    // must be like 'Jamm\\Memory' => array($vendorDir . '/jamm/memory/Jamm/Memory/lib'), 
);

```

The pull request will solve the compatibility issue by pointing to the correct folder.

Issue observed on composer version,

```
Composer version 1.0-dev (c291b07abde1d01323b07db06ab4227ff98c0191) 2015-02-23 22:41:42
```
